### PR TITLE
Improve test coverage.

### DIFF
--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
@@ -2,10 +2,11 @@ package com.dropbox.gradle.plugins.dependencyguard
 
 import com.dropbox.gradle.plugins.dependencyguard.fixture.Builder
 import com.dropbox.gradle.plugins.dependencyguard.fixture.SimpleProject
+import com.dropbox.gradle.plugins.dependencyguard.util.exists
+import com.dropbox.gradle.plugins.dependencyguard.util.readLines
+import com.dropbox.gradle.plugins.dependencyguard.util.readText
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
-import java.nio.file.Path
 
 class PluginTest {
 
@@ -15,6 +16,7 @@ class PluginTest {
       args = arrayOf(":lib:dependencyGuard")
     )
 
+    // verify baseline
     assertThat(result.output).contains(
       "Dependency Guard Dependency baseline created for :lib for configuration compileClasspath."
     )
@@ -25,8 +27,15 @@ class PluginTest {
     val lines = baseline.readLines()
     assertThat(lines).hasSize(1)
     assertThat(lines.single()).isEqualTo("commons-io:commons-io:2.11.0")
-  }
 
-  private fun Path.exists() = Files.exists(this)
-  private fun Path.readLines(): List<String> = Files.readAllLines(this).filter { it.isNotBlank() }
+    // verify tree baseline
+    val treeBaseline = project.projectFile("lib/dependencies/compileClasspath.tree.txt")
+    assertThat(treeBaseline.exists()).isTrue()
+    assertThat(treeBaseline.readText()).contains(
+      """
+        compileClasspath - Compile classpath for source set 'main'.
+        \--- commons-io:commons-io:2.11.0
+      """.trimIndent()
+    )
+  }
 }

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/fixture/SimpleProject.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/fixture/SimpleProject.kt
@@ -1,14 +1,10 @@
 package com.dropbox.gradle.plugins.dependencyguard.fixture
 
-import java.nio.file.Files
+import com.dropbox.gradle.plugins.dependencyguard.util.createDirectories
+import com.dropbox.gradle.plugins.dependencyguard.util.writeText
 import java.nio.file.Path
 
 class SimpleProject : AbstractProject() {
-
-  companion object {
-    // See build.gradle
-    private val pluginVersion = System.getProperty("pluginVersion").toString()
-  }
 
   private val gradlePropertiesFile = projectDir.resolve("gradle.properties")
   private val settingsFile = projectDir.resolve("settings.gradle")
@@ -28,26 +24,11 @@ class SimpleProject : AbstractProject() {
           gradlePluginPortal()
           mavenCentral()
         }
-        plugins {
-          id 'com.gradle.enterprise' version '3.10'
-        }
-      }
-      
-      plugins {
-        id 'com.gradle.enterprise'
       }
       
       dependencyResolutionManagement {
         repositories {
           mavenCentral()
-        }
-      }
-      
-      gradleEnterprise {
-        buildScan {
-          publishAlways()
-          termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-          termsOfServiceAgree = 'yes'
         }
       }
       
@@ -77,19 +58,13 @@ class SimpleProject : AbstractProject() {
       }
       
       dependencyGuard {
-        configuration('compileClasspath')
+        configuration('compileClasspath') {
+          tree = true
+        }
       }
       """.trimIndent()
     )
 
     return lib
-  }
-
-  private fun Path.writeText(content: String) {
-    Files.write(this, content.toByteArray())
-  }
-
-  private fun Path.createDirectories(): Path {
-    return Files.createDirectories(this)
   }
 }

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/util/path.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/util/path.kt
@@ -1,0 +1,10 @@
+package com.dropbox.gradle.plugins.dependencyguard.util
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+fun Path.exists(): Boolean = Files.exists(this)
+fun Path.createDirectories(): Path = Files.createDirectories(this)
+fun Path.readLines(): List<String> = Files.readAllLines(this).filter { it.isNotBlank() }
+fun Path.readText(): String = Files.readAllBytes(this).decodeToString()
+fun Path.writeText(content: String): Path = Files.write(this, content.toByteArray())


### PR DESCRIPTION
Move Path extension functions to util package. Delete build scan stuff from test fixture.

My main goal here was to ensure there was actual coverage for use of the `Action`-enhanced DSL (`tree = true`), and in the process decided to move the `Path` functions as well.