### PR TITLE
Use domain object container to avoid afterEvaluate.

### DIFF
--- a/dependency-guard/.gitignore
+++ b/dependency-guard/.gitignore
@@ -1,0 +1,3 @@
+gradlew
+gradlew.bat
+gradle

--- a/dependency-guard/api/dependency-guard.api
+++ b/dependency-guard/api/dependency-guard.api
@@ -1,9 +1,9 @@
-public final class com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration {
-	public fun <init> (Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;ZZZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public class com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration : org/gradle/api/Named {
+	public fun <init> (Ljava/lang/String;)V
 	public final fun getArtifacts ()Z
 	public final fun getConfigurationName ()Ljava/lang/String;
 	public final fun getModules ()Z
+	public fun getName ()Ljava/lang/String;
 	public final fun getTree ()Z
 	public final fun isAllowed ()Lkotlin/jvm/functions/Function1;
 	public final fun setAllowed (Lkotlin/jvm/functions/Function1;)V
@@ -19,8 +19,16 @@ public final class com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlu
 }
 
 public class com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPluginExtension {
-	public fun <init> ()V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun configuration (Ljava/lang/String;)V
 	public final fun configuration (Ljava/lang/String;Lorg/gradle/api/Action;)V
+}
+
+public abstract class com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public abstract fun getAvailableConfigurations ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getForRootProject ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMonitoredConfigurations ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getShouldBaseline ()Lorg/gradle/api/provider/Property;
 }
 

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
@@ -1,6 +1,6 @@
 package com.dropbox.gradle.plugins.dependencyguard
 
-import com.dropbox.gradle.plugins.dependencyguard.fixture.Builder
+import com.dropbox.gradle.plugins.dependencyguard.fixture.Builder.build
 import com.dropbox.gradle.plugins.dependencyguard.fixture.SimpleProject
 import com.dropbox.gradle.plugins.dependencyguard.util.exists
 import com.dropbox.gradle.plugins.dependencyguard.util.readLines
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 class PluginTest {
 
   @Test fun `can generate baseline`(): Unit = SimpleProject().use { project ->
-    val result = Builder.build(
+    val result = build(
       project = project,
       args = arrayOf(":lib:dependencyGuard")
     )

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration.kt
@@ -1,29 +1,45 @@
 package com.dropbox.gradle.plugins.dependencyguard
 
+import org.gradle.api.Named
+import org.gradle.api.tasks.Input
+import javax.inject.Inject
+
 /**
  * Configuration for [DependencyGuardPlugin]
  */
-public class DependencyGuardConfiguration(
+public open class DependencyGuardConfiguration @Inject constructor(
     /**
      * Name of the build configuration
      *
      * See all possibilities by running Gradle's built in ./gradlew project:dependencies
      */
+    @get:Input
     public val configurationName: String,
+) : Named {
+    @Input
+    public override fun getName(): String = configurationName
 
     /** Whether to include artifacts in the dependency list report */
-    public var artifacts: Boolean = true,
+    @get:Input
+    public var artifacts: Boolean = true
 
     /** Whether to include modules in the dependency list report */
-    public var modules: Boolean = true,
+    @get:Input
+    public var modules: Boolean = true
 
     /**
      * Whether to create the dependency tree report
      *
      * false by default because while valuable for debugging, get very noisy
      */
-    public var tree: Boolean = false,
+    @get:Input
+    public var tree: Boolean = false
 
-    /** Whether or not to allow a dependency */
-    public var isAllowed: (dependencyName: String) -> Boolean = { true },
-)
+    /**
+     * Whether to allow a dependency.
+     *
+     * TODO: not sure how to model this as a task input. May not matter since the task that uses it
+     *  can never be up-to-date.
+     */
+    public var isAllowed: (dependencyName: String) -> Boolean = { true }
+}

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlugin.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlugin.kt
@@ -1,6 +1,5 @@
 package com.dropbox.gradle.plugins.dependencyguard
 
-import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators.requirePluginConfig
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyTreeDiffTaskNames
 import com.dropbox.gradle.plugins.dependencyguard.internal.list.DependencyGuardListTask
 import com.dropbox.gradle.plugins.dependencyguard.internal.tree.BuildEnvironmentDependencyTreeDiffTask
@@ -8,6 +7,7 @@ import com.dropbox.gradle.plugins.dependencyguard.internal.tree.DependencyTreeDi
 import com.dropbox.gradle.plugins.dependencyguard.internal.isRootProject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
 
 /**
  * A plugin for watching dependency changes
@@ -25,106 +25,99 @@ public class DependencyGuardPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         val extension = target.extensions.create(
             DEPENDENCY_GUARD_TASK_NAME,
-            DependencyGuardPluginExtension::class.java
+            DependencyGuardPluginExtension::class.java,
+            target.objects
         )
 
-        registerTreeDiffTasks(target, extension)
-        registerDependencyGuardBaselineTask(target, extension)
-        registerDependencyGuardTask(target, extension)
+        val baselineTask = registerDependencyGuardBaselineTask(target, extension)
+        val guardTask = registerDependencyGuardTask(target, extension)
+        registerTreeDiffTasks(
+            target = target,
+            extension = extension,
+            baselineTask = baselineTask,
+            guardTask = guardTask
+        )
     }
 
     private fun registerDependencyGuardBaselineTask(
         target: Project,
         extension: DependencyGuardPluginExtension
-    ) {
-        target.tasks.register(
+    ): TaskProvider<DependencyGuardListTask> {
+        return target.tasks.register(
             DEPENDENCY_GUARD_BASELINE_TASK_NAME,
             DependencyGuardListTask::class.java
         ) {
             val task = this
             task.setParams(
+                project = target,
                 extension = extension,
                 shouldBaseline = true
             )
-            extension.configurations.forEach {
-                // Trigger the dependency tree diff task when treeReport is enabled
-                if (it.tree) {
-                    task.dependsOn(
-                        DependencyTreeDiffTaskNames.createDependencyTreeBaselineTaskNameForConfiguration(
-                            configurationName = it.configurationName
-                        )
-                    )
-                }
-            }
         }
     }
 
     private fun registerDependencyGuardTask(
         target: Project,
         extension: DependencyGuardPluginExtension
-    ) {
-        target.tasks.register(
+    ): TaskProvider<DependencyGuardListTask> {
+        return target.tasks.register(
             DEPENDENCY_GUARD_TASK_NAME,
             DependencyGuardListTask::class.java
         ) {
             val task = this
-            requirePluginConfig(target, extension)
             task.setParams(
+                project = target,
                 extension = extension,
                 shouldBaseline = false
             )
-
-            extension.configurations.forEach {
-                // Trigger the dependency tree diff task when treeReport is enabled
-                if (it.tree) {
-                    task.dependsOn(
-                        DependencyTreeDiffTaskNames.createDependencyTreeTaskNameForConfiguration(
-                            configurationName = it.configurationName
-                        )
-                    )
-                }
-            }
         }
     }
 
-    private fun registerTreeDiffTasks(target: Project, extension: DependencyGuardPluginExtension) {
-        // We must evaluate first so we have the extension data and all flavor configurations are recognized
-        target.afterEvaluate {
-            requirePluginConfig(target, extension)
-            extension.configurations
-                .filter { it.tree } // Only when treeReport is enabled
-                .forEach { dependencyGuardConfiguration ->
-
-                    // Register dependencyTreeDiff tasks for configuration
-                    val configurationName = dependencyGuardConfiguration.configurationName
-                    val taskClass = if (target.isRootProject()) {
-                        BuildEnvironmentDependencyTreeDiffTask::class.java
-                    } else {
-                        DependencyTreeDiffTask::class.java
-                    }
-                    target.tasks.register(
-                        DependencyTreeDiffTaskNames.createDependencyTreeTaskNameForConfiguration(
-                            configurationName = configurationName
-                        ),
-                        taskClass
-                    ) {
-                        setParams(
-                            configurationName = configurationName,
-                            shouldBaseline = false
-                        )
-                    }
-                    target.tasks.register(
-                        DependencyTreeDiffTaskNames.createDependencyTreeBaselineTaskNameForConfiguration(
-                            configurationName = configurationName
-                        ),
-                        taskClass
-                    ) {
-                        setParams(
-                            configurationName = configurationName,
-                            shouldBaseline = true
-                        )
-                    }
+    private fun registerTreeDiffTasks(
+        target: Project,
+        extension: DependencyGuardPluginExtension,
+        baselineTask: TaskProvider<DependencyGuardListTask>,
+        guardTask: TaskProvider<DependencyGuardListTask>
+    ) {
+        extension.configurations.all {
+            val dependencyGuardConfiguration = this
+            if (dependencyGuardConfiguration.tree) {
+                val taskClass = if (target.isRootProject()) {
+                    BuildEnvironmentDependencyTreeDiffTask::class.java
+                } else {
+                    DependencyTreeDiffTask::class.java
                 }
+
+                val treeGuardTask = target.tasks.register(
+                    DependencyTreeDiffTaskNames.createDependencyTreeTaskNameForConfiguration(
+                        configurationName = dependencyGuardConfiguration.configurationName
+                    ),
+                    taskClass
+                ) {
+                    setParams(
+                        configurationName = dependencyGuardConfiguration.configurationName,
+                        shouldBaseline = false
+                    )
+                }
+                guardTask.configure {
+                    dependsOn(treeGuardTask)
+                }
+
+                val treeBaselineTask = target.tasks.register(
+                    DependencyTreeDiffTaskNames.createDependencyTreeBaselineTaskNameForConfiguration(
+                        configurationName = dependencyGuardConfiguration.configurationName
+                    ),
+                    taskClass
+                ) {
+                    setParams(
+                        configurationName = dependencyGuardConfiguration.configurationName,
+                        shouldBaseline = true
+                    )
+                }
+                baselineTask.configure {
+                    dependsOn(treeBaselineTask)
+                }
+            }
         }
     }
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ProjectExt.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ProjectExt.kt
@@ -3,7 +3,7 @@ package com.dropbox.gradle.plugins.dependencyguard.internal
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import org.gradle.api.Project
 
-internal fun Project.isRootProject(): Boolean = (path == rootProject.path)
+internal fun Project.isRootProject(): Boolean = this == rootProject
 
 internal fun getQualifiedBaselineTaskForProjectPath(path: String): String {
     val separator = if (path == ":") "" else ":"


### PR DESCRIPTION
This draft PR is based on the test PR I made earlier (so you can ignore the first commit). I'm sharing this in its draft state to get your feedback on the general idea. In the end, the ultimate idea would be to remove the mutable list entirely from the extension.

One thing worth noting is that there's a subtle bug in the current implementation of the plugin. You use this function in your task configuration:
```kotlin
requirePluginConfig(target, extension)
```
That will fail if `extension.configurations` is empty. You are implicitly assuming that the `dependencyGuard` DSL block will be evaluated before tasks get configured. I can imagine a scenario that triggers task configuration early, causing a failure even though the build script is correctly configured. It would be a complex scenario, but people do crazy things in their builds and plugins. I think you'd be better off delaying that check to task execution.