### PR TITLE
Configuration: `isAllowed` -> `allowRule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A small single version bump of `androidx.activity` from `1.3.1` -> `1.4.0` cause
 ![](docs/images/002-bump-version-change-detected.gif)
 
 ## Custom Rules for Allowed Dependencies
-For a given configuration, you may never want `junit` to be shipped.  You can prevent this by modifying the `isAllowed` rule to return `!it.contains("junit")` for your situation.
+For a given configuration, you may never want `junit` to be shipped.  You can prevent this by modifying the `allowRule` rule to return `!it.contains("junit")` for your situation.
 
 ![](docs/images/007-filter-dependencies.gif)
 
@@ -85,7 +85,7 @@ If you have explicit test or debugging dependencies you never want to ship, you 
 ```kotlin
 dependencyGuard {
     configuration("releaseRuntimeClasspath") {
-        isAllowed = {
+        allowRule = {
             // Disallow dependencies with a name containing "test"
             !it.contains("junit")
         }
@@ -207,7 +207,7 @@ dependencyGuard {
     tree = false // Defaults to false
 
     // Filter through dependencies
-    isAllowed = {dependencyName: String ->
+    allowRule = {dependencyName: String ->
         return true // Defaults to true
     }
   }

--- a/dependency-guard/api/dependency-guard.api
+++ b/dependency-guard/api/dependency-guard.api
@@ -1,12 +1,12 @@
 public class com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration : org/gradle/api/Named {
 	public fun <init> (Ljava/lang/String;)V
+	public final fun getAllowRule ()Lkotlin/jvm/functions/Function1;
 	public final fun getArtifacts ()Z
 	public final fun getConfigurationName ()Ljava/lang/String;
 	public final fun getModules ()Z
 	public fun getName ()Ljava/lang/String;
 	public final fun getTree ()Z
-	public final fun isAllowed ()Lkotlin/jvm/functions/Function1;
-	public final fun setAllowed (Lkotlin/jvm/functions/Function1;)V
+	public final fun setAllowRule (Lkotlin/jvm/functions/Function1;)V
 	public final fun setArtifacts (Z)V
 	public final fun setModules (Z)V
 	public final fun setTree (Z)V

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardConfiguration.kt
@@ -36,10 +36,11 @@ public open class DependencyGuardConfiguration @Inject constructor(
     public var tree: Boolean = false
 
     /**
-     * Whether to allow a dependency.
+     * Rule to determine if a dependency will be allowed.
      *
      * TODO: not sure how to model this as a task input. May not matter since the task that uses it
      *  can never be up-to-date.
      */
-    public var isAllowed: (dependencyName: String) -> Boolean = { true }
+    @get:Input
+    public var allowRule: (dependencyName: String) -> Boolean = { true }
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -51,7 +51,7 @@ public abstract class DependencyGuardListTask : DefaultTask() {
         return DependencyGuardReportData(
             projectPath = project.path,
             configurationName = configurationName,
-            isAllowed = dependencyGuardConfiguration.isAllowed,
+            isAllowed = dependencyGuardConfiguration.allowRule,
             dependencies = dependencies,
         )
     }

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 dependencyGuard {
     // All dependencies included in Production Release APK
     configuration("releaseRuntimeClasspath") {
-        isAllowed = {
+        allowRule = {
             // Disallow dependencies with a name containing "test"
             !it.contains("test")
         }


### PR DESCRIPTION
@autonomousapps called out that `isAllowed` shows up as `allowed` in groovy syntax.  In order to avoid ambiguity, I'm renaming to `allowRule`.