### PR TITLE
Opt all tasks out of tracking and configuration caching.

### DIFF
--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
@@ -6,36 +6,61 @@ import com.dropbox.gradle.plugins.dependencyguard.util.exists
 import com.dropbox.gradle.plugins.dependencyguard.util.readLines
 import com.dropbox.gradle.plugins.dependencyguard.util.readText
 import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.Test
 
 class PluginTest {
 
-  @Test fun `can generate baseline`(): Unit = SimpleProject().use { project ->
-    val result = build(
-      project = project,
-      args = arrayOf(":lib:dependencyGuard")
-    )
+    @Test
+    fun `can generate baseline`(): Unit = SimpleProject().use { project ->
+        val result = build(
+            project = project,
+            args = arrayOf(":lib:dependencyGuard")
+        )
 
-    // verify baseline
-    assertThat(result.output).contains(
-      "Dependency Guard Dependency baseline created for :lib for configuration compileClasspath."
-    )
+        validateBuild(project, result)
+    }
 
-    val baseline = project.projectFile("lib/dependencies/compileClasspath.txt")
-    assertThat(baseline.exists()).isTrue()
+    @Test
+    fun `doesn't fall over when configuration cache is used`(): Unit = SimpleProject().use { project ->
+        val result = build(
+            project = project,
+            // Gradle 7.4 is the minimum version for which this feature is relevant
+            gradleVersion = GradleVersion.version("7.4"),
+            args = arrayOf(":lib:dependencyGuard", "--configuration-cache")
+        )
 
-    val lines = baseline.readLines()
-    assertThat(lines).hasSize(1)
-    assertThat(lines.single()).isEqualTo("commons-io:commons-io:2.11.0")
+        validateBuild(project, result)
 
-    // verify tree baseline
-    val treeBaseline = project.projectFile("lib/dependencies/compileClasspath.tree.txt")
-    assertThat(treeBaseline.exists()).isTrue()
-    assertThat(treeBaseline.readText()).contains(
-      """
-        compileClasspath - Compile classpath for source set 'main'.
-        \--- commons-io:commons-io:2.11.0
-      """.trimIndent()
-    )
-  }
+        // verify configuration-cache related stuff
+        assertThat(result.output)
+            .contains("Calculating task graph as no configuration cache is available for tasks: :lib:dependencyGuard")
+        assertThat(result.output)
+            .contains("problems were found storing the configuration cache")
+        // There is also the implicit test that the build succeeded, despite these problems.
+    }
+
+    private fun validateBuild(project: SimpleProject, result: BuildResult) {
+        // verify baseline
+        assertThat(result.output)
+            .contains("Dependency Guard Dependency baseline created for :lib for configuration compileClasspath.")
+
+        val baseline = project.projectFile("lib/dependencies/compileClasspath.txt")
+        assertThat(baseline.exists()).isTrue()
+
+        val lines = baseline.readLines()
+        assertThat(lines).hasSize(1)
+        assertThat(lines.single()).isEqualTo("commons-io:commons-io:2.11.0")
+
+        // verify tree baseline
+        val treeBaseline = project.projectFile("lib/dependencies/compileClasspath.tree.txt")
+        assertThat(treeBaseline.exists()).isTrue()
+        assertThat(treeBaseline.readText()).contains(
+            """
+              compileClasspath - Compile classpath for source set 'main'.
+              \--- commons-io:commons-io:2.11.0
+            """.trimIndent()
+        )
+    }
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -3,15 +3,10 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.list
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardConfiguration
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPluginExtension
-import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
+import com.dropbox.gradle.plugins.dependencyguard.internal.*
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators.requirePluginConfig
-import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardListReportWriter
-import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportData
-import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportType
-import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyVisitor
-import com.dropbox.gradle.plugins.dependencyguard.internal.isRootProject
-import com.dropbox.gradle.plugins.dependencyguard.internal.qualifiedBaselineTaskName
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.OutputFileUtils
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.Tasks.declareCompatibilities
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -21,7 +16,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
-import org.gradle.util.GradleVersion
 
 public abstract class DependencyGuardListTask : DefaultTask() {
 
@@ -183,10 +177,6 @@ public abstract class DependencyGuardListTask : DefaultTask() {
         this.monitoredConfigurations.set(extension.configurations)
         this.shouldBaseline.set(shouldBaseline)
 
-        if (GradleVersion.current() >= GradleVersion.version("7.3")) {
-            doNotTrackState("This task only outputs to console")
-        } else {
-            outputs.upToDateWhen { false }
-        }
+        declareCompatibilities()
     }
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/BuildEnvironmentDependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/BuildEnvironmentDependencyTreeDiffTask.kt
@@ -3,6 +3,7 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.tree
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.DependencyGuardTreeDiffer
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.Tasks.declareCompatibilities
 import org.gradle.api.Project
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.tasks.TaskAction
@@ -47,6 +48,8 @@ internal open class BuildEnvironmentDependencyTreeDiffTask : BuildEnvironmentRep
     override fun setParams(configurationName: String, shouldBaseline: Boolean) {
         this.shouldBaseline = shouldBaseline
         this.outputFile = dependencyGuardTreeDiffer.buildDirOutputFile
+
+        declareCompatibilities()
     }
 
     @TaskAction

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -3,6 +3,7 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.tree
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.DependencyGuardTreeDiffer
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.Tasks.declareCompatibilities
 import org.gradle.api.tasks.diagnostics.DependencyReportTask
 
 internal open class DependencyTreeDiffTask : DependencyReportTask(), TreeDiffTask {
@@ -36,5 +37,7 @@ internal open class DependencyTreeDiffTask : DependencyReportTask(), TreeDiffTas
         this.configurationName = configurationName
         super.setConfiguration(configurationName)
         this.outputFile = dependencyGuardTreeDiffer.buildDirOutputFile
+
+        declareCompatibilities()
     }
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/GradleVersion.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/GradleVersion.kt
@@ -1,0 +1,9 @@
+package com.dropbox.gradle.plugins.dependencyguard.internal.utils
+
+import org.gradle.util.GradleVersion
+
+internal object GradleVersion {
+    private val current = GradleVersion.current()
+    val isAtLeast73 = current >= GradleVersion.version("7.3")
+    val isAtLeast74 = current >= GradleVersion.version("7.4")
+}

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/Tasks.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/Tasks.kt
@@ -1,0 +1,19 @@
+package com.dropbox.gradle.plugins.dependencyguard.internal.utils
+
+import org.gradle.api.Task
+
+@Suppress("UnstableApiUsage")
+internal object Tasks {
+    fun Task.declareCompatibilities() {
+        if (GradleVersion.isAtLeast73) {
+            doNotTrackState("This task only outputs to console")
+        } else {
+            outputs.upToDateWhen { false }
+        }
+
+        // See also https://github.com/dropbox/dependency-guard/issues/4.
+        if (GradleVersion.isAtLeast74) {
+            notCompatibleWithConfigurationCache("Uses Project at execution time")
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dropbox/dependency-guard/issues/4.

See https://docs.gradle.org/current/userguide/configuration_cache.html for more information.

The point of `notCompatibleWithConfigurationCache("Uses Project at execution time")` is to tell Gradle that, if a user tries to run this task with the flag `org.gradle.unsafe.configuration-cache=true` set, then that flag should be ignored. Without that method call, then Gradle would instead fail the build. This lets users say they want CC on by default, while gracefully falling back to having it off for tasks that aren't compatible. Otherwise, they'd have to remember it doesn't work for tasks X, Y, and Z, and manually use `--no-configuration-cache`, which is annoying.

As an aside, something weird is happening with this project's .gitignore files. I had to manually add both files in the `utils` package.

```
git add dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/GradleVersion.kt
The following paths are ignored by one of your .gitignore files:
dependency-guard/src/main/kotlin/com/dropbox/gradle
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
```
I think it's the gitignore rule to ignore simply `gradle`.