### PR TITLE
Backport of the `String.capitalized()` extension for Pre Gradle 7.4.  Fixes #40

### DIFF
--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyTreeDiffTaskNames.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyTreeDiffTaskNames.kt
@@ -1,7 +1,5 @@
 package com.dropbox.gradle.plugins.dependencyguard.internal
 
-import org.gradle.configurationcache.extensions.capitalized
-
 internal object DependencyTreeDiffTaskNames {
 
     /**

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyTreeDiffTaskNames.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyTreeDiffTaskNames.kt
@@ -10,7 +10,7 @@ internal object DependencyTreeDiffTaskNames {
      *
      * Fixes: https://github.com/dropbox/dependency-guard/issues/40
      */
-    private fun String.capitalized(): String {
+    fun String.capitalized(): String {
         return if (this.isEmpty()) {
             ""
         } else {

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyTreeDiffTaskNames.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyTreeDiffTaskNames.kt
@@ -4,6 +4,25 @@ import org.gradle.configurationcache.extensions.capitalized
 
 internal object DependencyTreeDiffTaskNames {
 
+    /**
+     * This extension [org.gradle.configurationcache.extensions.capitalized]
+     * is not available until 7.4.x, so this is a backport.
+     *
+     * Fixes: https://github.com/dropbox/dependency-guard/issues/40
+     */
+    private fun String.capitalized(): String {
+        return if (this.isEmpty()) {
+            ""
+        } else {
+            val firstChar = get(0)
+            if (firstChar.isUpperCase()) {
+                return this
+            } else {
+                firstChar.toUpperCase() + substring(1)
+            }
+        }
+    }
+
     fun createDependencyTreeTaskNameForConfiguration(configurationName: String): String {
         return "dependencyTreeDiff${configurationName.capitalized()}"
     }

--- a/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/TaskNamesTest.kt
+++ b/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/TaskNamesTest.kt
@@ -1,0 +1,24 @@
+package com.dropbox.gradle.plugins.dependencyguard.internal
+
+import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyTreeDiffTaskNames.capitalized
+import org.gradle.configurationcache.extensions.capitalized
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TaskNamesTest {
+    @Test
+    fun `new library is added`() {
+        listOf(
+            "" to "",
+            "a" to "A",
+            "A" to "A",
+            "aa" to "Aa",
+            "aaa" to "Aaa",
+            "aA" to "AA",
+            "Aa" to "Aa",
+        ).forEach {
+            assertEquals(it.first.capitalized(), it.second)
+        }
+    }
+}

--- a/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/TaskNamesTest.kt
+++ b/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/TaskNamesTest.kt
@@ -1,9 +1,7 @@
 package com.dropbox.gradle.plugins.dependencyguard.internal
 
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyTreeDiffTaskNames.capitalized
-import org.gradle.configurationcache.extensions.capitalized
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class TaskNamesTest {


### PR DESCRIPTION
Backport of `String` extension `org.gradle.configurationcache.extensions.capitalized` for pre Gradle 7.4.

As long as there is consistency of the task name locally, it's not super critical that this be 100% correct, but I did do some tests, and seems simple enough.

cc: @mezpahlan #40