### PR TITLE
Configuration cache pt1

### DIFF
--- a/dependency-guard/api/dependency-guard.api
+++ b/dependency-guard/api/dependency-guard.api
@@ -28,7 +28,6 @@ public class com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPluginExt
 
 public abstract class com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask : org/gradle/api/DefaultTask {
 	public fun <init> ()V
-	public abstract fun getAvailableConfigurations ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getForRootProject ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMonitoredConfigurations ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getShouldBaseline ()Lorg/gradle/api/provider/Property;

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/PluginTest.kt
@@ -1,10 +1,12 @@
 package com.dropbox.gradle.plugins.dependencyguard
 
 import com.dropbox.gradle.plugins.dependencyguard.fixture.Builder.build
+import com.dropbox.gradle.plugins.dependencyguard.fixture.Builder.buildAndFail
+import com.dropbox.gradle.plugins.dependencyguard.fixture.FullProject
 import com.dropbox.gradle.plugins.dependencyguard.fixture.SimpleProject
-import com.dropbox.gradle.plugins.dependencyguard.util.exists
-import com.dropbox.gradle.plugins.dependencyguard.util.readLines
-import com.dropbox.gradle.plugins.dependencyguard.util.readText
+import com.dropbox.gradle.plugins.dependencyguard.util.assertFileExistsWithContentContains
+import com.dropbox.gradle.plugins.dependencyguard.util.assertFileExistsWithContentEqual
+import com.dropbox.gradle.plugins.dependencyguard.util.replaceText
 import com.google.common.truth.Truth.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
@@ -19,7 +21,7 @@ class PluginTest {
             args = arrayOf(":lib:dependencyGuard")
         )
 
-        validateBuild(project, result)
+        validateBaselineBuild(project, result)
     }
 
     @Test
@@ -31,7 +33,7 @@ class PluginTest {
             args = arrayOf(":lib:dependencyGuard", "--configuration-cache")
         )
 
-        validateBuild(project, result)
+        validateBaselineBuild(project, result)
 
         // verify configuration-cache related stuff
         assertThat(result.output)
@@ -41,26 +43,136 @@ class PluginTest {
         // There is also the implicit test that the build succeeded, despite these problems.
     }
 
-    private fun validateBuild(project: SimpleProject, result: BuildResult) {
+    private fun validateBaselineBuild(project: SimpleProject, result: BuildResult) {
         // verify baseline
         assertThat(result.output)
             .contains("Dependency Guard baseline created for :lib for configuration compileClasspath.")
 
-        val baseline = project.projectFile("lib/dependencies/compileClasspath.txt")
-        assertThat(baseline.exists()).isTrue()
-
-        val lines = baseline.readLines()
-        assertThat(lines).hasSize(1)
-        assertThat(lines.single()).isEqualTo("commons-io:commons-io:2.11.0")
+        project.assertFileExistsWithContentEqual(
+            filename = "lib/dependencies/compileClasspath.txt",
+            contentFile = "list_before_update.txt",
+        )
 
         // verify tree baseline
-        val treeBaseline = project.projectFile("lib/dependencies/compileClasspath.tree.txt")
-        assertThat(treeBaseline.exists()).isTrue()
-        assertThat(treeBaseline.readText()).contains(
-            """
-              compileClasspath - Compile classpath for source set 'main'.
-              \--- commons-io:commons-io:2.11.0
-            """.trimIndent()
+        project.assertFileExistsWithContentContains(
+            filename = "lib/dependencies/compileClasspath.tree.txt",
+            contentFile = "tree_before_update.txt",
         )
+    }
+
+    @Test
+    fun `guard with no dependencies changes`(): Unit = SimpleProject().use { project ->
+        // create baseline
+        build(
+            project = project,
+            args = arrayOf(":lib:dependencyGuard")
+        )
+
+        // check with no dependencies changes
+        val result = build(
+            project = project,
+            args = arrayOf(":lib:dependencyGuard")
+        )
+
+        assertThat(result.output)
+            .contains("No Dependency Changes Found in :lib for configuration \"compileClasspath\"")
+
+        project.assertFileExistsWithContentEqual(
+            filename = "lib/dependencies/compileClasspath.txt",
+            contentFile = "list_before_update.txt",
+        )
+
+        project.assertFileExistsWithContentContains(
+            filename = "lib/dependencies/compileClasspath.tree.txt",
+            contentFile = "tree_before_update.txt",
+        )
+    }
+
+    @Test
+    fun `guard after dependencies changes`(): Unit = SimpleProject().use { project ->
+        // create baseline
+        build(
+            project = project,
+            args = arrayOf(":lib:dependencyGuard")
+        )
+
+        project.lib.resolve("build.gradle").replaceText(
+            oldValue = "implementation 'io.reactivex.rxjava3:rxjava:3.1.4'",
+            newValue = "implementation 'io.reactivex.rxjava3:rxjava:3.1.5'",
+        )
+
+        // check after dependencies changes
+        val result = buildAndFail(
+            project = project,
+            args = arrayOf(":lib:dependencyGuard")
+        )
+
+        assertThat(result.output).contains("Dependency Tree comparison to baseline does not match.")
+        assertThat(result.output).contains(
+            """
+    [33m***** DEPENDENCY CHANGE DETECTED *****[0m
+    [31m-\--- io.reactivex.rxjava3:rxjava:3.1.4[0m
+    [31m-     \--- org.reactivestreams:reactive-streams:1.0.3[0m
+    [32m+\--- io.reactivex.rxjava3:rxjava:3.1.5[0m
+    [32m+     \--- org.reactivestreams:reactive-streams:1.0.4[0m
+        """.trimIndent()
+        )
+
+        project.assertFileExistsWithContentEqual(
+            filename = "lib/dependencies/compileClasspath.txt",
+            contentFile = "list_before_update.txt",
+        )
+
+        project.assertFileExistsWithContentContains(
+            filename = "lib/dependencies/compileClasspath.tree.txt",
+            contentFile = "tree_before_update.txt",
+        )
+    }
+
+    @Test
+    fun `baseline after dependencies changes`(): Unit = SimpleProject().use { project ->
+        // create baseline
+        build(
+            project = project,
+            args = arrayOf(":lib:dependencyGuard")
+        )
+
+        project.lib.resolve("build.gradle").replaceText(
+            oldValue = "implementation 'io.reactivex.rxjava3:rxjava:3.1.4'",
+            newValue = "implementation 'io.reactivex.rxjava3:rxjava:3.1.5'",
+        )
+
+        // check after dependencies changes
+        val result = build(
+            project = project,
+            args = arrayOf(":lib:dependencyGuardBaseline")
+        )
+
+        assertThat(result.output)
+            .contains("Dependency Guard baseline created for :lib for configuration compileClasspath")
+
+        project.assertFileExistsWithContentEqual(
+            filename = "lib/dependencies/compileClasspath.txt",
+            contentFile = "list_after_update.txt",
+        )
+
+        project.assertFileExistsWithContentContains(
+            filename = "lib/dependencies/compileClasspath.tree.txt",
+            contentFile = "tree_after_update.txt",
+        )
+    }
+
+    @Test
+    fun `can generate full report baseline`(): Unit = FullProject().use { project ->
+        val result = build(
+            project = project,
+            args = arrayOf("dependencyGuard")
+        )
+
+        assertThat(result.output).contains("Dependency Guard baseline created for : for configuration classpath.")
+        assertThat(result.output).contains("Dependency Guard baseline created for :lib for configuration compileClasspath.")
+        assertThat(result.output).contains("Dependency Guard baseline created for :lib for configuration testCompileClasspath.")
+        assertThat(result.output).contains("Dependency Guard Tree baseline created for :lib for configuration compileClasspath.")
+        assertThat(result.output).contains("Dependency Guard Tree baseline created for :lib for configuration testCompileClasspath.")
     }
 }

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/fixture/FullProject.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/fixture/FullProject.kt
@@ -1,0 +1,88 @@
+package com.dropbox.gradle.plugins.dependencyguard.fixture
+
+import com.dropbox.gradle.plugins.dependencyguard.util.createDirectories
+import com.dropbox.gradle.plugins.dependencyguard.util.writeText
+import java.nio.file.Path
+
+class FullProject : AbstractProject() {
+
+    private val gradlePropertiesFile = projectDir.resolve("gradle.properties")
+    private val settingsFile = projectDir.resolve("settings.gradle")
+    private val rootBuildFile = projectDir.resolve("build.gradle")
+
+    // Generate java library project named 'lib'
+    val lib = minimalLibrary("lib")
+
+    init {
+        gradlePropertiesFile.writeText(
+            """
+        org.gradle.jvmargs=-Dfile.encoding=UTF-8
+      """.trimIndent()
+        )
+
+        settingsFile.writeText(
+            """
+      pluginManagement {
+        repositories {
+          gradlePluginPortal()
+          mavenCentral()
+        }
+      }
+      
+      dependencyResolutionManagement {
+        repositories {
+          mavenCentral()
+        }
+      }
+      
+      rootProject.name = 'project-under-test'
+      
+      // Don't forget to add all your modules here!
+      include ':lib'
+      """.trimIndent()
+        )
+
+        rootBuildFile.writeText(
+            """
+            plugins {
+                id 'com.dropbox.dependency-guard'
+            }
+            
+            dependencyGuard {
+                configuration('classpath') {
+                    tree = false
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    private fun minimalLibrary(name: String): Path {
+        val lib = projectDir.resolve(name).createDirectories()
+
+        lib.resolve("build.gradle").writeText(
+            """
+      plugins {
+        id 'java-library'
+        id 'com.dropbox.dependency-guard'
+      }
+      
+      dependencies {
+        implementation 'io.reactivex.rxjava3:rxjava:3.1.4'
+        testImplementation 'junit:junit:4.13.2'
+      }
+      
+      dependencyGuard {
+        configuration('compileClasspath') {
+          tree = true
+        }
+        configuration('testCompileClasspath') {
+          tree = true
+        }
+      }
+      """.trimIndent()
+        )
+
+        return lib
+    }
+}

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/fixture/SimpleProject.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/fixture/SimpleProject.kt
@@ -10,6 +10,9 @@ class SimpleProject : AbstractProject() {
   private val settingsFile = projectDir.resolve("settings.gradle")
   private val rootBuildFile = projectDir.resolve("build.gradle")
 
+  // Generate java library project named 'lib'
+  val lib = minimalLibrary("lib")
+
   init {
     gradlePropertiesFile.writeText(
       """
@@ -38,9 +41,6 @@ class SimpleProject : AbstractProject() {
       include ':lib'
       """.trimIndent()
     )
-
-    // Generate java library project named 'lib'
-    val lib = minimalLibrary("lib")
   }
 
   private fun minimalLibrary(name: String): Path {
@@ -54,7 +54,7 @@ class SimpleProject : AbstractProject() {
       }
       
       dependencies {
-        implementation 'commons-io:commons-io:2.11.0' 
+        implementation 'io.reactivex.rxjava3:rxjava:3.1.4'
       }
       
       dependencyGuard {

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/util/FileChecks.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/util/FileChecks.kt
@@ -1,0 +1,37 @@
+package com.dropbox.gradle.plugins.dependencyguard.util
+
+import com.dropbox.gradle.plugins.dependencyguard.fixture.AbstractProject
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+
+fun AbstractProject.assertFileExistsWithContentEqual(
+    filename: String,
+    contentFile: String,
+) {
+    assertFileContent(filename, contentFile) { actualContent, expectedContent ->
+        assertThat(actualContent).isEqualTo(expectedContent)
+    }
+}
+
+fun AbstractProject.assertFileExistsWithContentContains(
+    filename: String,
+    contentFile: String,
+) {
+    assertFileContent(filename, contentFile) { actualContent, expectedContent ->
+        assertThat(actualContent).contains(expectedContent)
+    }
+}
+
+private fun AbstractProject.assertFileContent(
+    filename: String,
+    contentFile: String,
+    assertion: (actualContent: String, expectedContent: String) -> Unit,
+) {
+    val path = projectFile(filename)
+    assertThat(path.exists()).isTrue()
+
+    val actualContent = path.readText()
+    val expectedContent: String = File("src/gradleTest/resources/$contentFile").readText()
+    assertion(actualContent, expectedContent)
+}
+

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/util/path.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/util/path.kt
@@ -8,3 +8,4 @@ fun Path.createDirectories(): Path = Files.createDirectories(this)
 fun Path.readLines(): List<String> = Files.readAllLines(this).filter { it.isNotBlank() }
 fun Path.readText(): String = Files.readAllBytes(this).decodeToString()
 fun Path.writeText(content: String): Path = Files.write(this, content.toByteArray())
+fun Path.replaceText(oldValue: String, newValue: String): Path = writeText(readText().replace(oldValue, newValue))

--- a/dependency-guard/src/gradleTest/resources/list_after_update.txt
+++ b/dependency-guard/src/gradleTest/resources/list_after_update.txt
@@ -1,0 +1,2 @@
+io.reactivex.rxjava3:rxjava:3.1.5
+org.reactivestreams:reactive-streams:1.0.4

--- a/dependency-guard/src/gradleTest/resources/list_before_update.txt
+++ b/dependency-guard/src/gradleTest/resources/list_before_update.txt
@@ -1,0 +1,2 @@
+io.reactivex.rxjava3:rxjava:3.1.4
+org.reactivestreams:reactive-streams:1.0.3

--- a/dependency-guard/src/gradleTest/resources/tree_after_update.txt
+++ b/dependency-guard/src/gradleTest/resources/tree_after_update.txt
@@ -1,0 +1,3 @@
+compileClasspath - Compile classpath for source set 'main'.
+\--- io.reactivex.rxjava3:rxjava:3.1.5
+     \--- org.reactivestreams:reactive-streams:1.0.4

--- a/dependency-guard/src/gradleTest/resources/tree_before_update.txt
+++ b/dependency-guard/src/gradleTest/resources/tree_before_update.txt
@@ -1,0 +1,3 @@
+compileClasspath - Compile classpath for source set 'main'.
+\--- io.reactivex.rxjava3:rxjava:3.1.4
+     \--- org.reactivestreams:reactive-streams:1.0.3

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -69,10 +69,6 @@ public abstract class DependencyGuardListTask : DefaultTask() {
     @TaskAction
     internal fun execute() {
         val dependencyGuardConfigurations = monitoredConfigurations.get()
-        ConfigurationValidators.validateConfigurationsAreAvailable(
-            target = project,
-            configurationNames = dependencyGuardConfigurations.map { it.configurationName }
-        )
 
         val reports = mutableListOf<DependencyGuardReportData>().apply {
             dependencyGuardConfigurations.forEach { dependencyGuardConfig ->
@@ -174,6 +170,10 @@ public abstract class DependencyGuardListTask : DefaultTask() {
             isForRootProject = project.isRootProject(),
             availableConfigurations = project.configurations.map { it.name },
             monitoredConfigurations = extension.configurations.toList(),
+        )
+        ConfigurationValidators.validateConfigurationsAreAvailable(
+            target = project,
+            configurationNames = extension.configurations.map { it.configurationName }
         )
 
         this.forRootProject.set(project.isRootProject())

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -4,7 +4,6 @@ import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardConfiguration
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPluginExtension
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
-import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators.requirePluginConfig
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardListReportWriter
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportData
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportType
@@ -63,21 +62,12 @@ public abstract class DependencyGuardListTask : DefaultTask() {
     @get:Input
     public abstract val forRootProject: Property<Boolean>
 
-    @get:Input
-    public abstract val availableConfigurations: ListProperty<String>
-
     @get:Nested
     public abstract val monitoredConfigurations: ListProperty<DependencyGuardConfiguration>
 
     @Suppress("NestedBlockDepth")
     @TaskAction
     internal fun execute() {
-        requirePluginConfig(
-            isForRootProject = forRootProject.get(),
-            availableConfigurations = availableConfigurations.get(),
-            monitoredConfigurations = monitoredConfigurations.get()
-        )
-
         val dependencyGuardConfigurations = monitoredConfigurations.get()
         ConfigurationValidators.validateConfigurationsAreAvailable(
             target = project,
@@ -180,8 +170,13 @@ public abstract class DependencyGuardListTask : DefaultTask() {
         extension: DependencyGuardPluginExtension,
         shouldBaseline: Boolean
     ) {
+        ConfigurationValidators.requirePluginConfig(
+            isForRootProject = project.isRootProject(),
+            availableConfigurations = project.configurations.map { it.name },
+            monitoredConfigurations = extension.configurations.toList(),
+        )
+
         this.forRootProject.set(project.isRootProject())
-        this.availableConfigurations.set(project.configurations.map { it.name })
         this.monitoredConfigurations.set(extension.configurations)
         this.shouldBaseline.set(shouldBaseline)
 

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/BuildEnvironmentDependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/BuildEnvironmentDependencyTreeDiffTask.kt
@@ -2,7 +2,6 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.tree
 
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
-import com.dropbox.gradle.plugins.dependencyguard.internal.utils.ColorTerminal
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.DependencyGuardTreeDiffer
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.Tasks.declareCompatibilities
 import org.gradle.api.Project
@@ -35,18 +34,18 @@ internal open class BuildEnvironmentDependencyTreeDiffTask : BuildEnvironmentRep
 
     init {
         group = DependencyGuardPlugin.DEPENDENCY_GUARD_TASK_GROUP
-        this.doFirst {
-            ConfigurationValidators.validateConfigurationsAreAvailable(
-                project,
-                listOf(configurationName)
-            )
-        }
+
         this.doLast {
             dependencyGuardTreeDiffer.performDiff()
         }
     }
 
     override fun setParams(configurationName: String, shouldBaseline: Boolean) {
+        ConfigurationValidators.validateConfigurationsAreAvailable(
+            project,
+            listOf(configurationName)
+        )
+
         this.shouldBaseline = shouldBaseline
         this.outputFile = dependencyGuardTreeDiffer.buildDirOutputFile
 

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -22,17 +22,17 @@ internal open class DependencyTreeDiffTask : DependencyReportTask(), TreeDiffTas
 
     init {
         group = DependencyGuardPlugin.DEPENDENCY_GUARD_TASK_GROUP
-        this.doFirst {
-            ConfigurationValidators.validateConfigurationsAreAvailable(
-                project,
-                listOf(configurationName)
-            )
-        }
+
         this.doLast {
             dependencyGuardTreeDiffer.performDiff()
         }
     }
     override fun setParams(configurationName: String, shouldBaseline: Boolean) {
+        ConfigurationValidators.validateConfigurationsAreAvailable(
+            project,
+            listOf(configurationName)
+        )
+
         this.shouldBaseline = shouldBaseline
         this.configurationName = configurationName
         super.setConfiguration(configurationName)

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/DependencyGuardTreeDiffer.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/DependencyGuardTreeDiffer.kt
@@ -27,6 +27,8 @@ internal class DependencyGuardTreeDiffer(
         )
     }
 
+    private val projectPath = project.path
+
     @Suppress("NestedBlockDepth")
     fun performDiff() {
         val baseline: String? = readBaselineFile()
@@ -38,7 +40,7 @@ internal class DependencyGuardTreeDiffer(
 
             ColorTerminal.printlnColor(
                 ColorTerminal.ANSI_YELLOW,
-                "Dependency Guard Tree baseline created for ${project.path} for configuration $configurationName."
+                "Dependency Guard Tree baseline created for $projectPath for configuration $configurationName."
             )
             ColorTerminal.printlnColor(
                 ColorTerminal.ANSI_YELLOW,

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR is the part 1 (first 5 commits) of #51 to simplify reviewing and merging.

1. more test cases added to be more confident when making large changes and refactoring afterwards.
1. usage of `project` property during task's execution (`@TaskAction`) breaks configuration cache. That's why `project.path` is now saved while configuring the task in `DependencyGuardTreeDiffer`.
1. checks from `ConfigurationValidators` are now called in tasks's configurationAction instead of `@TaskAction` to avoid breaking  configuration cache (these validations use `project` property). 
1. gradle version is bumped to 7.5.1.

Like in original PR, changes are split to commits to simplify review.