### PR TITLE
Bump to 0.4.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 0.4.0
+
+* Support for Configuration Cache by [@qwert2603](https://github.com/qwert2603) in [#51](https://github.com/dropbox/dependency-guard/pull/51)
+
 ## Version 0.3.2
 
 _2022-09-14_

--- a/dependency-guard/gradle.properties
+++ b/dependency-guard/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.dropbox.dependency-guard
-VERSION_NAME=0.3.3-SNAPSHOT
+VERSION_NAME=0.4.0-SNAPSHOT
 
 POM_ARTIFACT_ID=dependency-guard
 POM_NAME=Dependency Guard


### PR DESCRIPTION
Configuration Cache Support was merged, so time to bump up the version for this snapshot.