### PR TITLE
Fix: Uses Provider<ResolvedComponentResult> as input to Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Version 0.4.1 ([All Changes](https://github.com/dropbox/dependency-guard/compare/0.4.0...0.4.1))
+
+_2023-01-23_
+
+* Fixes [#67](https://github.com/dropbox/dependency-guard/issues/67): Configuration Cache by [@handstandsam](https://github.com/handstandsam) in [#70](https://github.com/dropbox/dependency-guard/pull/70)
+* Compatibility: **Requires Gradle 7.4 or Higher** in order to support Configuration Cache.
+
 ## Version 0.4.0 ([All Changes](https://github.com/dropbox/dependency-guard/compare/0.3.2...0.4.0))
 
 _2023-01-17_

--- a/dependency-guard/build.gradle.kts
+++ b/dependency-guard/build.gradle.kts
@@ -88,7 +88,7 @@ testing {
       useJUnitJupiter()
       dependencies {
         // gradleTest test suite depends on the production code in tests
-        implementation(project(project.path))
+        implementation(project)
         implementation(libs.truth)
       }
 

--- a/dependency-guard/build.gradle.kts
+++ b/dependency-guard/build.gradle.kts
@@ -88,7 +88,7 @@ testing {
       useJUnitJupiter()
       dependencies {
         // gradleTest test suite depends on the production code in tests
-        implementation(project)
+        implementation(project(project.path))
         implementation(libs.truth)
       }
 

--- a/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/GradleVersionArgumentsProvider.kt
+++ b/dependency-guard/src/gradleTest/kotlin/com/dropbox/gradle/plugins/dependencyguard/GradleVersionArgumentsProvider.kt
@@ -10,7 +10,6 @@ class GradleVersionArgumentsProvider : ArgumentsProvider {
 
     override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream
         .of(
-            ParameterizedPluginArgs(gradleVersion = GradleVersion.version("7.3.3"), withConfigurationCache = false),
             ParameterizedPluginArgs(gradleVersion = GradleVersion.version("7.4.2"), withConfigurationCache = false),
             ParameterizedPluginArgs(gradleVersion = GradleVersion.version("7.4.2"), withConfigurationCache = true),
             ParameterizedPluginArgs(gradleVersion = GradleVersion.version("7.5.1"), withConfigurationCache = false),

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlugin.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlugin.kt
@@ -16,6 +16,8 @@ public class DependencyGuardPlugin : Plugin<Project> {
     internal companion object {
         internal const val DEPENDENCY_GUARD_TASK_GROUP = "Dependency Guard"
 
+        internal const val DEPENDENCY_GUARD_EXTENSION_NAME = "dependencyGuard"
+
         internal const val DEPENDENCY_GUARD_TASK_NAME = "dependencyGuard"
 
         internal const val DEPENDENCY_GUARD_BASELINE_TASK_NAME = "dependencyGuardBaseline"
@@ -23,7 +25,7 @@ public class DependencyGuardPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         val extension = target.extensions.create(
-            DEPENDENCY_GUARD_TASK_NAME,
+            DEPENDENCY_GUARD_EXTENSION_NAME,
             DependencyGuardPluginExtension::class.java,
             target.objects
         )

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ConfigurationValidators.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ConfigurationValidators.kt
@@ -27,23 +27,23 @@ internal object ConfigurationValidators {
                 }.toString()
                 throw GradleException(message)
             }
-            return
-        }
-        val configurationNames = monitoredConfigurations.map { it.configurationName }
-        require(configurationNames.isNotEmpty() && configurationNames[0].isNotBlank()) {
-            StringBuilder().apply {
-                appendLine("Error: No configurations provided to Dependency Guard Plugin.")
-                appendLine("Here are some valid configurations you could use.")
-                appendLine("")
-                val availableConfigNames = availableConfigurations
-                    .filter { isClasspathConfig(it) }
+        } else {
+            val configurationNames = monitoredConfigurations.map { it.configurationName }
+            require(configurationNames.isNotEmpty() && configurationNames[0].isNotBlank()) {
+                StringBuilder().apply {
+                    appendLine("Error: No configurations provided to Dependency Guard Plugin.")
+                    appendLine("Here are some valid configurations you could use.")
+                    appendLine("")
+                    val availableConfigNames = availableConfigurations
+                        .filter { isClasspathConfig(it) }
 
-                appendLine("dependencyGuard {")
-                availableConfigNames.forEach {
-                    appendLine("""  configuration("$it")""")
-                }
-                appendLine("}")
-            }.toString()
+                    appendLine("dependencyGuard {")
+                    availableConfigNames.forEach {
+                        appendLine("""  configuration("$it")""")
+                    }
+                    appendLine("}")
+                }.toString()
+            }
         }
     }
 

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ProjectExt.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ProjectExt.kt
@@ -4,6 +4,7 @@ import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.provider.Provider
 
 internal fun Project.isRootProject(): Boolean = this == rootProject
 
@@ -19,8 +20,8 @@ internal val Project.projectConfigurations: ConfigurationContainer
         configurations
     }
 
-internal fun ConfigurationContainer.getResolvedComponentResult(name: String): ResolvedComponentResult = this
+internal fun ConfigurationContainer.getResolvedComponentResult(name: String): Provider<ResolvedComponentResult> = this
     .getByName(name)
     .incoming
     .resolutionResult
-    .root
+    .rootComponent

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -10,6 +10,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 


### PR DESCRIPTION
Following documentation on config cache https://docs.gradle.org/current/userguide/configuration_cache.html

Hopefully fixes #67 and #68

---

Chose to drop support for Gradle 7.3.x.  `resolutionRoot` was unavailable prior to Gradle 7.4.
<img width="1434" alt="Screen Shot 2023-01-23 at 10 14 32 AM" src="https://user-images.githubusercontent.com/264948/214076032-64c66d03-076c-489e-bcb1-280e99316e85.png">
