### PR TITLE
FIX: Config Cache - TreeTask & ListTask

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,5 @@ allprojects {
 }
 
 dependencyGuard {
-    configuration("classpath") {
-        it.tree = true
-    }
+    configuration("classpath")
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyGuardListReportWriter.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyGuardListReportWriter.kt
@@ -14,7 +14,6 @@ internal class DependencyGuardListReportWriter(
      * @return Whether changes were detected
      */
     internal fun writeReport(
-        buildDirOutputFile: File,
         projectDirOutputFile: File,
         report: DependencyGuardReportData,
         shouldBaseline: Boolean,
@@ -23,8 +22,6 @@ internal class DependencyGuardListReportWriter(
             artifacts = artifacts,
             modules = modules
         )
-
-        buildDirOutputFile.writeText(reportContent)
 
         val projectDirOutputFileExists = projectDirOutputFile.exists()
         return if (shouldBaseline || !projectDirOutputFileExists) {

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 internal abstract class DependencyGuardListTask : DefaultTask() {
@@ -60,11 +61,11 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
     @get:Input
     abstract val monitoredConfigurationsMap: MapProperty<DependencyGuardConfiguration, Provider<ResolvedComponentResult>>
 
-    @get:Input
-    abstract val buildDirectory: DirectoryProperty
+    @get:OutputDirectory
+    abstract val buildDirectoryDependencyGuardTempDir: DirectoryProperty
 
-    @get:Input
-    abstract val projectDirectory: DirectoryProperty
+    @get:OutputDirectory
+    abstract val projectDirectoryDependenciesDir: DirectoryProperty
 
     @Suppress("NestedBlockDepth")
     @TaskAction
@@ -122,14 +123,15 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
             artifacts = dependencyGuardConfig.artifacts,
             modules = dependencyGuardConfig.modules
         )
+
         return reportWriter.writeReport(
             buildDirOutputFile = OutputFileUtils.buildDirOutputFile(
-                buildDirectory = buildDirectory.get(),
+                buildDirectory = buildDirectoryDependencyGuardTempDir.get(),
                 configurationName = report.configurationName,
                 reportType = reportType,
             ),
             projectDirOutputFile = OutputFileUtils.projectDirOutputFile(
-                projectDirectory = projectDirectory.get(),
+                projectDirectory = projectDirectoryDependenciesDir.get(),
                 configurationName = report.configurationName,
                 reportType = reportType,
             ),
@@ -176,8 +178,14 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
         this.projectPath.set(project.path)
         this.monitoredConfigurationsMap.set(resolveMonitoredConfigurationsMap(project, extension.configurations))
         this.shouldBaseline.set(shouldBaseline)
-        this.buildDirectory.set(project.layout.buildDirectory)
-        this.projectDirectory.set(project.layout.projectDirectory)
+
+
+
+        val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
+        val buildDgTempDir = OutputFileUtils.buildDirDependencyGuardTmpDir(project.layout.buildDirectory.get())
+
+        this.buildDirectoryDependencyGuardTempDir.set(projectDependenciesDir)
+        this.projectDirectoryDependenciesDir.set(buildDgTempDir)
 
         declareCompatibilities()
     }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -179,8 +179,6 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
         this.monitoredConfigurationsMap.set(resolveMonitoredConfigurationsMap(project, extension.configurations))
         this.shouldBaseline.set(shouldBaseline)
 
-
-
         val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
         val buildDgTempDir = OutputFileUtils.buildDirDependencyGuardTmpDir(project.layout.buildDirectory.get())
 

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -62,9 +62,6 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
     abstract val monitoredConfigurationsMap: MapProperty<DependencyGuardConfiguration, Provider<ResolvedComponentResult>>
 
     @get:OutputDirectory
-    abstract val buildDirectoryDependencyGuardTempDir: DirectoryProperty
-
-    @get:OutputDirectory
     abstract val projectDirectoryDependenciesDir: DirectoryProperty
 
     @Suppress("NestedBlockDepth")
@@ -125,11 +122,6 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
         )
 
         return reportWriter.writeReport(
-            buildDirOutputFile = OutputFileUtils.buildDirOutputFile(
-                buildDirectory = buildDirectoryDependencyGuardTempDir.get(),
-                configurationName = report.configurationName,
-                reportType = reportType,
-            ),
             projectDirOutputFile = OutputFileUtils.projectDirOutputFile(
                 projectDirectory = projectDirectoryDependenciesDir.get(),
                 configurationName = report.configurationName,
@@ -178,12 +170,8 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
         this.projectPath.set(project.path)
         this.monitoredConfigurationsMap.set(resolveMonitoredConfigurationsMap(project, extension.configurations))
         this.shouldBaseline.set(shouldBaseline)
-
-        val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
-        val buildDgTempDir = OutputFileUtils.buildDirDependencyGuardTmpDir(project.layout.buildDirectory.get())
-
-        this.buildDirectoryDependencyGuardTempDir.set(projectDependenciesDir)
-        this.projectDirectoryDependenciesDir.set(buildDgTempDir)
+        val projectDirDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
+        this.projectDirectoryDependenciesDir.set(projectDirDependenciesDir)
 
         declareCompatibilities()
     }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -170,7 +170,7 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
         this.projectPath.set(project.path)
         this.monitoredConfigurationsMap.set(resolveMonitoredConfigurationsMap(project, extension.configurations))
         this.shouldBaseline.set(shouldBaseline)
-        val projectDirDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
+        val projectDirDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project)
         this.projectDirectoryDependenciesDir.set(projectDirDependenciesDir)
 
         declareCompatibilities()

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -53,7 +53,7 @@ internal abstract class DependencyTreeDiffTask : DefaultTask() {
             project,
             listOf(configurationName)
         )
-        val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
+        val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project)
         val projectDirOutputFile: File = DependencyGuardTreeDiffer.projectDirOutputFile(projectDependenciesDir, configurationName)
         val buildDirOutputFile: File = DependencyGuardTreeDiffer.buildDirOutputFile(project.layout.buildDirectory.get(), configurationName)
         val projectPath = project.path

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -5,6 +5,7 @@ import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidato
 import com.dropbox.gradle.plugins.dependencyguard.internal.getResolvedComponentResult
 import com.dropbox.gradle.plugins.dependencyguard.internal.projectConfigurations
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.DependencyGuardTreeDiffer
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.OutputFileUtils
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.Tasks.declareCompatibilities
 import java.io.File
 import org.gradle.api.DefaultTask
@@ -52,7 +53,8 @@ internal abstract class DependencyTreeDiffTask : DefaultTask() {
             project,
             listOf(configurationName)
         )
-        val projectDirOutputFile: File = DependencyGuardTreeDiffer.projectDirOutputFile(project.layout.projectDirectory, configurationName)
+        val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project.layout.projectDirectory)
+        val projectDirOutputFile: File = DependencyGuardTreeDiffer.projectDirOutputFile(projectDependenciesDir, configurationName)
         val buildDirOutputFile: File = DependencyGuardTreeDiffer.buildDirOutputFile(project.layout.buildDirectory.get(), configurationName)
         val projectPath = project.path
         val resolvedComponentResult = project.projectConfigurations.getResolvedComponentResult(configurationName)

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/DependencyGuardTreeDiffer.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/DependencyGuardTreeDiffer.kt
@@ -1,29 +1,32 @@
 package com.dropbox.gradle.plugins.dependencyguard.internal.utils
 
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportType
-import org.gradle.api.GradleException
-import org.gradle.api.Project
 import java.io.File
+import org.gradle.api.GradleException
+import org.gradle.api.file.Directory
 
 internal class DependencyGuardTreeDiffer(
-    project: Project,
     private val configurationName: String,
     private val shouldBaseline: Boolean,
+    private val projectDirOutputFile: File,
+    private val buildDirOutputFile: File,
+    private val projectPath: String,
 ) {
+    companion object {
+        fun projectDirOutputFile(projectDirectory: Directory, configurationName: String): File =
+            OutputFileUtils.projectDirOutputFile(
+                projectDirectory = projectDirectory,
+                configurationName = configurationName,
+                reportType = DependencyGuardReportType.TREE,
+            )
 
-    private val projectDirOutputFile: File = OutputFileUtils.projectDirOutputFile(
-        projectDirectory = project.layout.projectDirectory,
-        configurationName = configurationName,
-        reportType = DependencyGuardReportType.TREE,
-    )
 
-    val buildDirOutputFile: File = OutputFileUtils.buildDirOutputFile(
-        buildDirectory = project.layout.buildDirectory.get(),
-        configurationName = configurationName,
-        reportType = DependencyGuardReportType.TREE,
-    )
-
-    private val projectPath = project.path
+        fun buildDirOutputFile(buildDirectory: Directory, configurationName: String): File = OutputFileUtils.buildDirOutputFile(
+            buildDirectory = buildDirectory,
+            configurationName = configurationName,
+            reportType = DependencyGuardReportType.TREE,
+        )
+    }
 
     @Suppress("NestedBlockDepth")
     fun performDiff() {

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
@@ -1,10 +1,44 @@
 package com.dropbox.gradle.plugins.dependencyguard.internal.utils
 
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportType
-import org.gradle.api.file.Directory
 import java.io.File
+import org.gradle.api.file.Directory
 
 internal object OutputFileUtils {
+
+    fun buildDirDependencyGuardTmpDir(
+        buildDirectory: Directory,
+    ): Directory {
+        val tempDir = buildDirectory
+            .dir("tmp/dependency-guard")
+
+        tempDir.asFile
+            .apply {
+                if (!exists()) {
+                    // Create the "tmp/dependency-guard" directory if it does not exist
+                    mkdirs()
+                }
+            }
+        return tempDir
+    }
+
+
+    fun projectDirDependenciesDir(
+        projectDirectory: Directory,
+    ): Directory {
+        val dependenciesDir = projectDirectory
+            .dir("dependencies")
+        dependenciesDir
+            .asFile
+            .apply {
+                if (!exists()) {
+                    // Create the "dependencies" directory if it does not exist
+                    mkdirs()
+                }
+            }
+        return dependenciesDir
+    }
+
     fun buildDirOutputFile(
         buildDirectory: Directory,
         configurationName: String,
@@ -12,17 +46,8 @@ internal object OutputFileUtils {
     ): File {
         val configurationNameAndSuffix = "$configurationName${reportType.fileSuffix}"
         return buildDirectory
-            .dir("tmp/dependency-guard")
             .file("$configurationNameAndSuffix.txt")
             .asFile
-            .apply {
-                parentFile.apply {
-                    if (!exists()) {
-                        // Create the "dependencies" directory if it does not exist
-                        mkdirs()
-                    }
-                }
-            }
     }
 
     fun projectDirOutputFile(

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
@@ -48,6 +48,14 @@ internal object OutputFileUtils {
         return buildDirectory
             .file("$configurationNameAndSuffix.txt")
             .asFile
+            .apply {
+                parentFile.apply {
+                    if (!exists()) {
+                        // Create the directory if it does not exist
+                        mkdirs()
+                    }
+                }
+            }
     }
 
     fun projectDirOutputFile(

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
@@ -2,37 +2,21 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.utils
 
 import com.dropbox.gradle.plugins.dependencyguard.internal.DependencyGuardReportType
 import java.io.File
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 
 internal object OutputFileUtils {
 
-    fun buildDirDependencyGuardTmpDir(
-        buildDirectory: Directory,
-    ): Directory {
-        val tempDir = buildDirectory
-            .dir("tmp/dependency-guard")
-
-        tempDir.asFile
-            .apply {
-                if (!exists()) {
-                    // Create the "tmp/dependency-guard" directory if it does not exist
-                    mkdirs()
-                }
-            }
-        return tempDir
-    }
-
-
     fun projectDirDependenciesDir(
-        projectDirectory: Directory,
+        project: Project,
     ): Directory {
-        val dependenciesDir = projectDirectory
+        val dependenciesDir = project.layout.projectDirectory
             .dir("dependencies")
         dependenciesDir
             .asFile
             .apply {
                 if (!exists()) {
-                    // Create the "dependencies" directory if it does not exist
+                    // Create the directory if it does not exist
                     mkdirs()
                 }
             }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/OutputFileUtils.kt
@@ -57,18 +57,15 @@ internal object OutputFileUtils {
     ): File {
         val configurationNameAndSuffix = "${reportType.filePrefix}$configurationName${reportType.fileSuffix}"
         return projectDirectory
-            .dir("dependencies")
             .file("$configurationNameAndSuffix.txt")
             .asFile
             .apply {
                 parentFile.apply {
                     if (!exists()) {
-                        // Create the "dependencies" directory if it does not exist
+                        // Create the directory if it does not exist
                         mkdirs()
                     }
                 }
             }
     }
-
-    private const val DIRECTORY_NAME = "dependency-guard"
 }

--- a/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyGuardReportDataTest.kt
+++ b/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/DependencyGuardReportDataTest.kt
@@ -145,7 +145,6 @@ internal class DependencyGuardReportDataTest {
     }
 
     private class TestDelegate {
-        private val buildDirOutputFile = File.createTempFile("buildDir", ".txt")
         private val projectDirOutputFile = File.createTempFile("projectDir", ".txt")
         private val reportWriter = DependencyGuardListReportWriter(
             artifacts = true,
@@ -154,7 +153,6 @@ internal class DependencyGuardReportDataTest {
 
         fun whenReportWritten(report: DependencyGuardReportData, shouldBaseline: Boolean): DependencyListDiffResult {
             return reportWriter.writeReport(
-                buildDirOutputFile = buildDirOutputFile,
                 projectDirOutputFile = projectDirOutputFile,
                 report = report,
                 shouldBaseline = shouldBaseline,

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -21,6 +21,7 @@ dependencyGuard {
     // All dependencies included in Production Release APK
     configuration("releaseRuntimeClasspath") {
         modules = true
+        tree = true
         allowedFilter = {
             // Disallow dependencies with a name containing "test"
             !it.contains("test")

--- a/sample/app/dependencies/releaseRuntimeClasspath.tree.txt
+++ b/sample/app/dependencies/releaseRuntimeClasspath.tree.txt
@@ -1,0 +1,54 @@
++--- project :sample:module1
+|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.10
+|    |    |    +--- org.jetbrains:annotations:13.0
+|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.10
+|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10
+|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.10 (*)
+|    \--- project :sample:module2
+|         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10 (*)
+|         \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2
+|              \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.2
+|                   +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.30 -> 1.6.10 (*)
+|                   \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.30 -> 1.6.10
+\--- androidx.activity:activity:1.4.0
+     +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     +--- androidx.core:core:1.7.0
+     |    +--- androidx.annotation:annotation:1.2.0
+     |    +--- androidx.annotation:annotation-experimental:1.1.0
+     |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1
+     |    |    +--- androidx.arch.core:core-runtime:2.1.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     |    |    |    \--- androidx.arch.core:core-common:2.1.0
+     |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.3.1
+     |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     |    |    +--- androidx.arch.core:core-common:2.1.0 (*)
+     |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     |    +--- androidx.versionedparcelable:versionedparcelable:1.1.1
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     |    |    \--- androidx.collection:collection:1.0.0
+     |    |         \--- androidx.annotation:annotation:1.0.0 -> 1.2.0
+     |    +--- androidx.collection:collection:1.0.0 (*)
+     |    \--- androidx.concurrent:concurrent-futures:1.0.0
+     |         +--- com.google.guava:listenablefuture:1.0
+     |         \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     +--- androidx.lifecycle:lifecycle-runtime:2.3.1 (*)
+     +--- androidx.lifecycle:lifecycle-viewmodel:2.3.1
+     |    \--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     +--- androidx.savedstate:savedstate:1.1.0
+     |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0
+     |    +--- androidx.arch.core:core-common:2.0.1 -> 2.1.0 (*)
+     |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.3.1 (*)
+     +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1
+     |    +--- androidx.annotation:annotation:1.0.0 -> 1.2.0
+     |    +--- androidx.savedstate:savedstate:1.1.0 (*)
+     |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.1
+     |    |    +--- androidx.arch.core:core-common:2.1.0 (*)
+     |    |    +--- androidx.arch.core:core-runtime:2.1.0 (*)
+     |    |    \--- androidx.lifecycle:lifecycle-common:2.3.1 (*)
+     |    \--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 (*)
+     +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31 -> 1.6.10 (*)
+     +--- androidx.collection:collection:1.0.0 (*)
+     \--- androidx.tracing:tracing:1.0.0
+          \--- androidx.annotation:annotation:1.1.0 -> 1.2.0


### PR DESCRIPTION
Found more issues with config cache, so worked on that.

List Task:
*  Changed from an Input to an Output. These directories are where we write our files, and then we perform the diff in the task.  These are NOT inputs, and we do not need to track them.  `@get:Input abstract val projectDirectory: DirectoryProperty` -> `@get:OutputDirectory abstract val projectDirectoryDependenciesDir: DirectoryProperty`

Tree Task:
* `Project` was being held in a var which breaks config cache.  That has been fixed.


Targets #67, #68, #69