### PR TITLE
Added better error messaging when no classpath configurations are found.

### DIFF
--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -157,6 +157,7 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
         shouldBaseline: Boolean
     ) {
         ConfigurationValidators.requirePluginConfig(
+            projectPath = project.path,
             isForRootProject = project.isRootProject(),
             availableConfigurations = project.configurations.map { it.name },
             monitoredConfigurations = extension.configurations.toList(),


### PR DESCRIPTION
We have legacy code that tried to grab `tasks.getByName("dependencyGuard")` on the a project.  It caused the error message of:

```
* What went wrong:
A problem occurred evaluating project ':myapp'.
> Failed to apply plugin 'com.dropbox.dependency-guard'.
   > Could not create task ':myapp:dependencyGuard'.
      > Error: No configurations provided to Dependency Guard Plugin.
        Here are some valid configurations you could use.
        
        dependencyGuard {
        }   
```


This new messaging is much improved and provides the user with some guidance.