### PR TITLE
Split kotlin and dokka versions references

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "1.6.10"
+dokka = "1.6.10"
 coroutines = "1.6.0"
 androidx-activity = "1.4.0"
 
@@ -12,7 +13,7 @@ coroutines = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.19.0" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.9.0" }


### PR DESCRIPTION
While they seem to match, they are not directly linked. The release frequency of both library are not synced.