### PR TITLE
[Work in Progress] Move Configuration Validation to Task Execution Time

### DIFF
--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlugin.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPlugin.kt
@@ -65,9 +65,11 @@ public class DependencyGuardPlugin : Plugin<Project> {
         ) {
             val task = this
             task.setParams(
-                project = target,
+                target = target,
                 extension = extension,
-                shouldBaseline = true
+                shouldBaseline = true,
+                availableConfigurationNames = target.configurations.map { it.name },
+
             )
         }
     }
@@ -82,9 +84,10 @@ public class DependencyGuardPlugin : Plugin<Project> {
         ) {
             val task = this
             task.setParams(
-                project = target,
+                target = target,
                 extension = extension,
-                shouldBaseline = false
+                shouldBaseline = false,
+                availableConfigurationNames = target.configurations.map { it.name },
             )
         }
     }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPluginExtension.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/DependencyGuardPluginExtension.kt
@@ -1,8 +1,8 @@
 package com.dropbox.gradle.plugins.dependencyguard
 
+import javax.inject.Inject
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
-import javax.inject.Inject
 
 /**
  * Extension for [DependencyGuardPlugin] which leverages [DependencyGuardConfiguration]
@@ -10,6 +10,7 @@ import javax.inject.Inject
 public open class DependencyGuardPluginExtension @Inject constructor(
     private val objects: ObjectFactory
 ) {
+
     internal val configurations = objects.domainObjectContainer(DependencyGuardConfiguration::class.java)
 
     public fun configuration(name: String) {

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -3,6 +3,7 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.tree
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
 import com.dropbox.gradle.plugins.dependencyguard.internal.getResolvedComponentResult
+import com.dropbox.gradle.plugins.dependencyguard.internal.isRootProject
 import com.dropbox.gradle.plugins.dependencyguard.internal.projectConfigurations
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.DependencyGuardTreeDiffer
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.OutputFileUtils
@@ -11,12 +12,9 @@ import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedComponentResult
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -49,14 +47,19 @@ internal abstract class DependencyTreeDiffTask : DefaultTask() {
         configurationName: String,
         shouldBaseline: Boolean,
     ) {
+        val projectPath = project.path
+
         ConfigurationValidators.validateConfigurationsAreAvailable(
-            project,
-            listOf(configurationName)
+            forRootProject = project.isRootProject(),
+            logger = logger,
+            projectPath = projectPath,
+            availableConfigurationNames = project.configurations.map { it.name },
+            monitoredConfigurationNames = listOf(configurationName)
         )
+
         val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project)
         val projectDirOutputFile: File = DependencyGuardTreeDiffer.projectDirOutputFile(projectDependenciesDir, configurationName)
         val buildDirOutputFile: File = DependencyGuardTreeDiffer.buildDirOutputFile(project.layout.buildDirectory.get(), configurationName)
-        val projectPath = project.path
         val resolvedComponentResult = project.projectConfigurations.getResolvedComponentResult(configurationName)
 
         this.resolvedComponentResult.set(resolvedComponentResult)


### PR DESCRIPTION
### For Issue https://github.com/dropbox/dependency-guard/issues/87

Probably want to separate out a few pieces into different diffs and think about this more.  Looking to get rid of issues of validation when configurations are not available yet for some users.
----
* Moved configuration validation to task execution time.  This is because many users were seeing the "no configurations available" message due to some ordering issues in some projects.
* Moved logic to static methods for cleaner code with more primitive inputs.