### PR TITLE
Using Primitives in Static Validator Methods

### DIFF
--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ConfigurationValidators.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/ConfigurationValidators.kt
@@ -3,8 +3,8 @@ package com.dropbox.gradle.plugins.dependencyguard.internal
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardConfiguration
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import org.gradle.api.GradleException
-import org.gradle.api.Project
 import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
 internal object ConfigurationValidators {
@@ -15,11 +15,11 @@ internal object ConfigurationValidators {
         projectPath: String,
         isForRootProject: Boolean,
         availableConfigurations: List<String>,
-        monitoredConfigurations: List<DependencyGuardConfiguration>
+        monitoredConfigurations: List<String>
     ) {
         if (isForRootProject) {
             logger.info("Configured for Root Project")
-            if (monitoredConfigurations.isNotEmpty() && monitoredConfigurations.first().configurationName != ScriptHandler.CLASSPATH_CONFIGURATION) {
+            if (monitoredConfigurations.isNotEmpty() && monitoredConfigurations.first() != ScriptHandler.CLASSPATH_CONFIGURATION) {
                 logger.error("If you wish to use dependency guard on your root project, use the following config:")
                 throw GradleException("""
                     dependencyGuard {
@@ -43,7 +43,7 @@ internal object ConfigurationValidators {
                 }
             }
 
-            val configurationNames = monitoredConfigurations.map { it.configurationName }
+            val configurationNames = monitoredConfigurations.map { it }
             require(configurationNames.isNotEmpty() && configurationNames[0].isNotBlank()) {
                 buildString {
                     appendLine("Error: No configurations provided to Dependency Guard Plugin.")
@@ -70,14 +70,17 @@ internal object ConfigurationValidators {
         )
     }
 
-    fun validateConfigurationsAreAvailable(
-        target: Project,
-        configurationNames: List<String>
-    ) {
-        val logger = target.logger
 
-        if (target.isRootProject()) {
-            if (configurationNames != listOf(ScriptHandler.CLASSPATH_CONFIGURATION)) {
+    fun validateConfigurationsAreAvailable(
+        isForRootProject: Boolean,
+        projectPath: String,
+        logger: Logger,
+        availableConfigurationNames: Collection<String>,
+        monitoredConfigurationNames: List<String>
+    ) {
+
+        if (isForRootProject) {
+            if (monitoredConfigurationNames != listOf(ScriptHandler.CLASSPATH_CONFIGURATION)) {
                 throw GradleException(
                     """
                         For the root project, the only allowed configuration is ${ScriptHandler.CLASSPATH_CONFIGURATION}.
@@ -91,22 +94,22 @@ internal object ConfigurationValidators {
             return
         }
 
-        configurationNames.forEach { configurationName ->
-            target.configurations
-                .firstOrNull { it.name == configurationName }
+        monitoredConfigurationNames.forEach { configurationName ->
+            availableConfigurationNames
+                .firstOrNull { it == configurationName }
                 ?: run {
-                    val availableClasspathConfigs = target.configurations
+                    val availableClasspathConfigs = availableConfigurationNames
                         .filter {
-                            isClasspathConfig(it.name)
+                            isClasspathConfig(it)
                         }
                     if (availableClasspathConfigs.isNotEmpty()) {
-                        logger.quiet("Available Configurations for ${target.path}:")
+                        logger.quiet("Available Configurations for $projectPath:")
                         availableClasspathConfigs.forEach {
-                            logger.quiet("* " + it.name)
+                            logger.quiet("* $it")
                         }
                     }
                     throw GradleException(
-                        "Configuration with name $configurationName was not found for ${target.path}"
+                        "Configuration with name $configurationName was not found for $projectPath"
                     )
                 }
         }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/list/DependencyGuardListTask.kt
@@ -91,10 +91,12 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
                         // Add to exception message without color
                         exceptionMessage.appendLine(diffResult.createDiffMessage(withColor = false))
                     }
+
                     is DependencyListDiffResult.DiffPerformed.NoDiff -> {
                         // Print no diff message
                         println(diffResult.noDiffMessage)
                     }
+
                     is DependencyListDiffResult.BaselineCreated -> {
                         println(diffResult.baselineCreatedMessage(true))
                     }
@@ -160,11 +162,14 @@ internal abstract class DependencyGuardListTask : DefaultTask() {
             projectPath = project.path,
             isForRootProject = project.isRootProject(),
             availableConfigurations = project.configurations.map { it.name },
-            monitoredConfigurations = extension.configurations.toList(),
+            monitoredConfigurations = extension.configurations.map { it.configurationName },
         )
         ConfigurationValidators.validateConfigurationsAreAvailable(
-            target = project,
-            configurationNames = extension.configurations.map { it.configurationName }
+            isForRootProject = project.isRootProject(),
+            projectPath = project.path,
+            logger = project.logger,
+            availableConfigurationNames = project.configurations.map { it.name },
+            monitoredConfigurationNames = extension.configurations.map { it.configurationName }
         )
 
         this.forRootProject.set(project.isRootProject())

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/tree/DependencyTreeDiffTask.kt
@@ -3,6 +3,7 @@ package com.dropbox.gradle.plugins.dependencyguard.internal.tree
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.internal.ConfigurationValidators
 import com.dropbox.gradle.plugins.dependencyguard.internal.getResolvedComponentResult
+import com.dropbox.gradle.plugins.dependencyguard.internal.isRootProject
 import com.dropbox.gradle.plugins.dependencyguard.internal.projectConfigurations
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.DependencyGuardTreeDiffer
 import com.dropbox.gradle.plugins.dependencyguard.internal.utils.OutputFileUtils
@@ -50,8 +51,11 @@ internal abstract class DependencyTreeDiffTask : DefaultTask() {
         shouldBaseline: Boolean,
     ) {
         ConfigurationValidators.validateConfigurationsAreAvailable(
-            project,
-            listOf(configurationName)
+            isForRootProject = project.isRootProject(),
+            projectPath = project.path,
+            logger = project.logger,
+            availableConfigurationNames = project.configurations.map { it.name },
+            monitoredConfigurationNames = listOf(configurationName)
         )
         val projectDependenciesDir = OutputFileUtils.projectDirDependenciesDir(project)
         val projectDirOutputFile: File = DependencyGuardTreeDiffer.projectDirOutputFile(projectDependenciesDir, configurationName)


### PR DESCRIPTION
Small cleanup to pass in more primitive values into the validators.  The goal here was to remove some of the complexity of passing around a `Project` object.