### PR TITLE
Prepare for 0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 0.4.3 ([All Changes](https://github.com/dropbox/dependency-guard/compare/0.4.2...0.4.3))
+
+_2023-03-14_
+
+* Fixes [#87](https://github.com/dropbox/dependency-guard/issues/87): Race Condition during `afterEvaluate` Configuration Validation in 0.4.2 by [@handstandsam](https://github.com/handstandsam) in [#90](https://github.com/dropbox/dependency-guard/pull/90)
+
 ## Version 0.4.2 ([All Changes](https://github.com/dropbox/dependency-guard/compare/0.4.1...0.4.2))
 
 _2023-03-13_

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ As platform engineers, we do a lot of library upgrades, and needed insight into 
 ```kotlin
 // sample/app/build.gradle.kts
 plugins {
-  id("com.dropbox.dependency-guard") version "0.4.2"
+  id("com.dropbox.dependency-guard") version "0.4.3"
 }
 ```
 
@@ -254,7 +254,7 @@ buildscript {
         maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
     }
     dependencies {
-        classpath("com.dropbox.dependency-guard:dependency-guard:0.4.2")
+        classpath("com.dropbox.dependency-guard:dependency-guard:0.4.3")
     }
 }
 ```

--- a/dependency-guard/gradle.properties
+++ b/dependency-guard/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.dropbox.dependency-guard
-VERSION_NAME=0.4.3-SNAPSHOT
+VERSION_NAME=0.4.3
 
 POM_ARTIFACT_ID=dependency-guard
 POM_NAME=Dependency Guard


### PR DESCRIPTION
Validated the SNAPSHOT on a monorepo and a couple other projects.  It fixed the issue in `0.4.2`, so going to merge to release!