### PR TITLE
Fix diff text lines missing

### DIFF
--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLines.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLines.kt
@@ -26,12 +26,11 @@ internal data class RemovedAndAddedLines(
 
     val diffTextWithPlusAndMinusWithColor: String = diffTextWithPlusAndMinus.lines().joinToString(separator = "") {
         val line = if (it.startsWith("-")) {
-            ColorTerminal.colorify(ColorTerminal.ANSI_RED, it)
+            ColorTerminal.colorify(ColorTerminal.ANSI_RED, it) + '\n'
         } else if (it.startsWith("+")) {
-            ColorTerminal.colorify(ColorTerminal.ANSI_GREEN, it)
+            ColorTerminal.colorify(ColorTerminal.ANSI_GREEN, it) + '\n'
         } else {
             it
         }
-        line + '\n'
     }
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLines.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLines.kt
@@ -15,22 +15,23 @@ internal data class RemovedAndAddedLines(
         }
     }.sortedBy { it.str }
 
-    val diffTextWithPlusAndMinus: String = diffLines.joinToString(separator = "") {
-        val prefix = if (it.added) {
-            "+ "
-        } else {
-            "- "
-        }
-        prefix + it.str + '\n'
-    }
+    val diffTextWithPlusAndMinus: String = diffLines.fold(StringBuilder()) { builder, it ->
+        builder.appendLine(
+            if (it.added) {
+                "+ ${it.str}"
+            } else {
+                "- ${it.str}"
+            }
+        )
+    }.toString()
 
-    val diffTextWithPlusAndMinusWithColor: String = diffTextWithPlusAndMinus.lines().joinToString(separator = "") {
-        val line = if (it.startsWith("-")) {
-            ColorTerminal.colorify(ColorTerminal.ANSI_RED, it) + '\n'
-        } else if (it.startsWith("+")) {
-            ColorTerminal.colorify(ColorTerminal.ANSI_GREEN, it) + '\n'
-        } else {
-            it
-        }
-    }
+    val diffTextWithPlusAndMinusWithColor: String = diffLines.fold(StringBuilder()) { builder, it ->
+        builder.appendLine(
+            if (it.added) {
+                ColorTerminal.colorify(ColorTerminal.ANSI_GREEN, "+ ${it.str}")
+            } else {
+                ColorTerminal.colorify(ColorTerminal.ANSI_RED, "- ${it.str}")
+            }
+        )
+    }.toString()
 }

--- a/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLines.kt
+++ b/dependency-guard/src/main/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLines.kt
@@ -21,16 +21,17 @@ internal data class RemovedAndAddedLines(
         } else {
             "- "
         }
-        prefix + it.str + "\n"
+        prefix + it.str + '\n'
     }
 
     val diffTextWithPlusAndMinusWithColor: String = diffTextWithPlusAndMinus.lines().joinToString(separator = "") {
-        if (it.startsWith("-")) {
+        val line = if (it.startsWith("-")) {
             ColorTerminal.colorify(ColorTerminal.ANSI_RED, it)
         } else if (it.startsWith("+")) {
             ColorTerminal.colorify(ColorTerminal.ANSI_GREEN, it)
         } else {
             it
-        } + "\n"
+        }
+        line + '\n'
     }
 }

--- a/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLinesTest.kt
+++ b/dependency-guard/src/test/kotlin/com/dropbox/gradle/plugins/dependencyguard/internal/utils/RemovedAndAddedLinesTest.kt
@@ -1,0 +1,61 @@
+package com.dropbox.gradle.plugins.dependencyguard.internal.utils
+
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.ColorTerminal.ANSI_GREEN
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.ColorTerminal.ANSI_RED
+import com.dropbox.gradle.plugins.dependencyguard.internal.utils.ColorTerminal.colorify
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class RemovedAndAddedLinesTest {
+
+    @Test
+    fun `hasDifference returns false`() {
+        val lines = RemovedAndAddedLines(
+            addedLines = emptyList(),
+            removedLines = emptyList(),
+        )
+        assertThat(lines.hasDifference).isFalse()
+    }
+
+    @Test
+    fun `hasDifference returns true`() {
+        val lines = RemovedAndAddedLines(
+            addedLines = listOf("androidx.activity:activity:1.4.0"),
+            removedLines = listOf("androidx.activity:activity:1.3.1"),
+        )
+        assertThat(lines.hasDifference).isTrue()
+    }
+
+    @Test
+    fun `diffTextWithPlusAndMinus formatting`() {
+        val lines = RemovedAndAddedLines(
+            addedLines = listOf("androidx.activity:activity:1.4.0"),
+            removedLines = listOf("androidx.activity:activity:1.3.1"),
+        )
+        assertThat(lines.diffTextWithPlusAndMinus)
+            .isEqualTo(
+                """
+                - androidx.activity:activity:1.3.1
+                + androidx.activity:activity:1.4.0
+                
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `diffTextWithPlusAndMinusWithColor formatting`() {
+        val lines = RemovedAndAddedLines(
+            addedLines = listOf("androidx.activity:activity:1.4.0"),
+            removedLines = listOf("androidx.activity:activity:1.3.1"),
+        )
+        assertThat(lines.diffTextWithPlusAndMinusWithColor)
+            .isEqualTo(
+                """
+                ${colorify(ANSI_RED, "- androidx.activity:activity:1.3.1")}
+                ${colorify(ANSI_GREEN, "+ androidx.activity:activity:1.4.0")}
+                
+                """.trimIndent()
+            )
+    }
+
+}


### PR DESCRIPTION
The `\n` was added only if the first condition was false because of if/else priorities.

```kotlin
if (a) {
  /**/
} else if (b) {
  /**/
} else {
  /**/
} + x
```

is in fact executed as

```kotlin
if (a) {
  /**/
} else {
    if (b) {
      /**/
    } else {
      /**/
    } + x
}
```

Closing #94